### PR TITLE
Update tb's debezium pg_replication_slots name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,9 @@ rows that looks like this:
 log_bin           = mysql-bin
 binlog_format     = row
 ```
+
+## Build and Run.
+
+To build and run `tb`, do the following:
+1. [mvn clean && mvn install] ()https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html)
+2. Run the newly created .jar with `java -jar [path to jar] [args]`

--- a/src/main/java/io/materialize/Binlogger.java
+++ b/src/main/java/io/materialize/Binlogger.java
@@ -85,6 +85,9 @@ public class Binlogger implements Consumer<SourceRecord> {
         b = b.with("database.dbname", db);
         b = b.with("database.server.name", "binlogger");
         b = b.with("offset.storage.file.filename", "/dev/null"); // TODO: support resuming(#1).
+        // Need a distinct pg_replication_slots name, "debezium" is already taken via
+        // standard Materialize setup.
+        b = b.with("slot.name", "tb_debezium");
         b = b.with("plugin.name", "pgoutput");
 
         Configuration config = b.build();


### PR DESCRIPTION
As mentioned in the comment, `debezium` is already taken by default in the Materialize developer setup.

Also, add a simple `Build and Run` to the README.md to anyone less familiar with Java. @rjnn, I know you mentioned `mvn install` didn't work for you, but it seems like that step should include `mvn package`?