### PR TITLE
Adding support for trx topic in tb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,25 +38,30 @@
     </dependency>
     <!-- schema management/introspection -->
     <dependency>
-      <groupId>io.debezium</groupId>
-      <artifactId>debezium-embedded</artifactId>
-      <version>0.10.0.Final</version>
+    <groupId>io.debezium</groupId>
+    <artifactId>debezium-api</artifactId>
+    <version>1.1.0.Final</version>
     </dependency>
     <dependency>
+    <groupId>io.debezium</groupId>
+    <artifactId>debezium-embedded</artifactId>
+    <version>1.1.0.Final</version>
+    </dependency>
+   <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-connector-mysql</artifactId>
-      <version>0.10.0.Final</version>
+      <version>1.1.0.Final</version>
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-connector-postgres</artifactId>
-      <version>0.10.0.Final</version>
+      <version>1.1.0.Final</version>
     </dependency>
     <!-- serialization -->
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-api</artifactId>
-      <version>2.3.0</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>io.confluent</groupId>

--- a/src/main/java/io/materialize/Binlogger.java
+++ b/src/main/java/io/materialize/Binlogger.java
@@ -78,8 +78,8 @@ public class Binlogger implements Consumer<SourceRecord> {
         parser.addArgument("-H", "--hostname").help("Database hostname").setDefault("localhost");
         parser.addArgument("-d", "--database").help("Database").setDefault("postgres");
         parser.addArgument("-u", "--user").help("User").setDefault("postgres");
-        parser.addArgument("--dir").help("Directory to output all serialized data to");
-        parser.addArgument("-S", "--save-file").help("file to keep current replication status in");
+        parser.addArgument("--dir").help("Directory to output all serialized data to").setDefault(".");
+        parser.addArgument("-S", "--save-file").help("file to keep current replication status in").setDefault("tb");
         parser.addArgument("--replication-slot").help("The postgres replication slot to use, "+
                 "must be distinct across multiple instances of tb").setDefault("tb");
 
@@ -111,7 +111,10 @@ public class Binlogger implements Consumer<SourceRecord> {
             .with("offset.storage.file.filename", getNsString(ns, "save_file") + ".offsets")
             .with("offset.flush.interval.ms", 5000)
             .with("database.history", "io.debezium.relational.history.FileDatabaseHistory")
-            .with("database.history.file.filename", getNsString(ns, "save_file") + ".history");
+            .with("database.history.file.filename", getNsString(ns, "save_file") + ".history")
+            .with("provide.transaction.metadata", true)
+            .with("provide.transaction.metadata.file.filename", getNsString(ns, "save_file") + ".trx");
+
 
         if (type.equals("mysql")) {
             b = b.with("connector.class", "io.debezium.connector.mysql.MySqlConnector").with("name",


### PR DESCRIPTION
This PR configures TB to automatically generate a transaction metadata topic when running with the Debezium Postgres Connector.

It bumps the Debezium version to 1.1 and the Kafka Connect version to 2.4.